### PR TITLE
feat: show weekly usage reset time in popover

### DIFF
--- a/ClaudeTokenCat/Sources/PopoverView.swift
+++ b/ClaudeTokenCat/Sources/PopoverView.swift
@@ -109,6 +109,12 @@ struct PopoverView: View {
                         }
                     }
                     .frame(height: 4)
+
+                    if let formatted = usageManager.weeklyResetFormatted {
+                        Text("Resets \(formatted)")
+                            .font(.caption)
+                            .foregroundColor(.secondary)
+                    }
                 }
             }
 


### PR DESCRIPTION
## Summary

- Parse the existing `resets_at` field from the `seven_day` usage bucket and display the weekly reset time (e.g. "Resets Fri 6:23 PM") below the weekly progress bar in the popover
- Uses the same ISO8601 date parsing as the session reset countdown

Closes #1

## Test plan

- [ ] Build and run the app (`./build.sh && open build/ClaudeTokenCat.app`)
- [ ] Open the popover and verify a "Resets <weekday> <time>" caption appears below the weekly usage bar

🤖 Generated with [Claude Code](https://claude.com/claude-code)