### PR TITLE
feat: add toggle to pause menu bar animation

### DIFF
--- a/ClaudeTokenCat/Sources/PopoverView.swift
+++ b/ClaudeTokenCat/Sources/PopoverView.swift
@@ -229,18 +229,26 @@ struct PopoverView: View {
 
             Divider()
 
-            // Quit
-            Button(action: {
-                NSApplication.shared.terminate(nil)
-            }) {
-                HStack(spacing: 4) {
-                    Image(systemName: "power")
-                    Text("Quit")
+            // Quit + Animation toggle
+            HStack {
+                Button(action: {
+                    NSApplication.shared.terminate(nil)
+                }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "power")
+                        Text("Quit")
+                    }
+                    .font(.caption)
                 }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+
+                Spacer()
+
+                Toggle("Animate", isOn: $usageManager.animationEnabled)
                 .font(.caption)
+                .toggleStyle(MiniSwitchStyle())
             }
-            .buttonStyle(.plain)
-            .foregroundColor(.secondary)
         }
         .padding(16)
         .frame(width: 280)
@@ -263,5 +271,29 @@ struct PopoverView: View {
             return String(format: "%.1fk", Double(count) / 1000.0)
         }
         return "\(count)"
+    }
+}
+
+// MARK: - Mini Switch Toggle Style
+
+/// Custom switch style that reliably shows blue/gray in NSPopover contexts,
+/// where the native NSSwitch ignores `.tint()`.
+private struct MiniSwitchStyle: ToggleStyle {
+    func makeBody(configuration: Configuration) -> some View {
+        HStack(spacing: 4) {
+            configuration.label
+            ZStack(alignment: configuration.isOn ? .trailing : .leading) {
+                Capsule()
+                    .fill(configuration.isOn ? Color.blue : Color.gray.opacity(0.3))
+                    .frame(width: 26, height: 15)
+                Circle()
+                    .fill(.white)
+                    .shadow(color: .black.opacity(0.2), radius: 0.5, y: 0.5)
+                    .frame(width: 13, height: 13)
+                    .padding(.horizontal, 1)
+            }
+            .animation(.easeInOut(duration: 0.15), value: configuration.isOn)
+            .onTapGesture { configuration.isOn.toggle() }
+        }
     }
 }

--- a/ClaudeTokenCat/Sources/TokenUsageManager.swift
+++ b/ClaudeTokenCat/Sources/TokenUsageManager.swift
@@ -10,6 +10,10 @@ final class TokenUsageManager: ObservableObject {
 
     // MARK: - Published State
 
+    @Published var animationEnabled: Bool = (UserDefaults.standard.object(forKey: "animationEnabled") as? Bool) ?? true {
+        didSet { UserDefaults.standard.set(animationEnabled, forKey: "animationEnabled") }
+    }
+
     @Published private(set) var usagePercent: Double = 0
     @Published private(set) var weeklyUsagePercent: Double = 0
     @Published private(set) var extraUsageEnabled: Bool = false


### PR DESCRIPTION
## Summary

- Adds an "Animate" toggle in the popover (next to Quit) to pause/resume the menu bar cat animation
- When paused, the cat shows a static sprite for the current usage state
- Setting persists across app restarts via UserDefaults
- Uses a custom SwiftUI toggle style (`MiniSwitchStyle`) to reliably render blue/gray in NSPopover contexts, where the native `NSSwitch` ignores `.tint()`

Closes #2

## Test plan

- Launch app — toggle should show blue (on) by default, cat animates
- Toggle off — cat freezes on first frame, toggle turns gray
- Toggle on — animation resumes, toggle turns blue
- Quit and relaunch — setting persists
- Change usage state while paused — static sprite updates to new state