### PR TITLE
feat: Add Settings panel with animation, percentage, and reset format toggles

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Summary
+
+<!-- Brief description of what this PR does and why -->
+
+## Changes
+
+<!-- List of specific changes made -->
+
+## Verification
+
+<!-- List of what was tested and how -->

--- a/ClaudeTokenCat/Sources/AppDelegate.swift
+++ b/ClaudeTokenCat/Sources/AppDelegate.swift
@@ -28,7 +28,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     // MARK: - Status Bar
 
     private func setupStatusItem() {
-        statusItem = NSStatusBar.system.statusItem(withLength: CGFloat(CatSpriteRenderer.spriteWidth))
+        statusItem = NSStatusBar.system.statusItem(withLength: NSStatusItem.variableLength)
 
         if let button = statusItem.button {
             button.action = #selector(showMenu)
@@ -75,6 +75,7 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 if newState != self.currentState {
                     self.switchToState(newState)
                 }
+                self.updatePercentageDisplay()
             }
             .store(in: &cancellables)
 
@@ -86,6 +87,14 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
                 self.switchToState(self.currentState)
             }
             .store(in: &cancellables)
+
+        // Watch for percentage display toggle
+        usageManager.$showPercentageInMenuBar
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] _ in
+                self?.updatePercentageDisplay()
+            }
+            .store(in: &cancellables)
     }
 
     private func switchToState(_ state: CatState) {
@@ -94,9 +103,8 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
         currentFrameIndex = 0
 
         // Set first frame immediately
-        if let first = currentFrames.first {
-            statusItem.button?.image = first
-        }
+        currentFrameIndex = 0
+        updateStatusImage()
 
         // Restart animation timer (only when not paused)
         animationTimer?.invalidate()
@@ -116,7 +124,50 @@ final class AppDelegate: NSObject, NSApplicationDelegate {
     private func advanceFrame() {
         guard !currentFrames.isEmpty else { return }
         currentFrameIndex = (currentFrameIndex + 1) % currentFrames.count
-        statusItem.button?.image = currentFrames[currentFrameIndex]
+        updateStatusImage()
+    }
+
+    private func updatePercentageDisplay() {
+        updateStatusImage()
+    }
+
+    /// Composites percentage text into the cat image so the cat never shifts position when toggling.
+    private func updateStatusImage() {
+        guard !currentFrames.isEmpty else { return }
+        let catFrame = currentFrames[currentFrameIndex]
+
+        if usageManager.showPercentageInMenuBar && usageManager.isSessionActive {
+            statusItem.button?.image = compositeImage(catFrame: catFrame, text: "\(Int(usageManager.usagePercent))%")
+        } else {
+            statusItem.button?.image = catFrame
+        }
+    }
+
+    private func compositeImage(catFrame: NSImage, text: String) -> NSImage {
+        let font = NSFont.monospacedDigitSystemFont(ofSize: 11, weight: .regular)
+        let attrs: [NSAttributedString.Key: Any] = [
+            .font: font,
+            .foregroundColor: NSColor.black,
+        ]
+        let textSize = (text as NSString).size(withAttributes: attrs)
+        let spacing: CGFloat = 6
+        let totalWidth = textSize.width + spacing + catFrame.size.width
+        let height = max(catFrame.size.height, textSize.height)
+
+        let composite = NSImage(size: NSSize(width: totalWidth, height: height))
+        composite.lockFocus()
+        (text as NSString).draw(
+            at: NSPoint(x: 0, y: (height - textSize.height) / 2),
+            withAttributes: attrs
+        )
+        catFrame.draw(
+            in: NSRect(x: textSize.width + spacing, y: (height - catFrame.size.height) / 2,
+                       width: catFrame.size.width, height: catFrame.size.height),
+            from: .zero, operation: .sourceOver, fraction: 1.0
+        )
+        composite.unlockFocus()
+        composite.isTemplate = true
+        return composite
     }
 
     /// Different states animate at different speeds.

--- a/ClaudeTokenCat/Sources/AppDelegate.swift
+++ b/ClaudeTokenCat/Sources/AppDelegate.swift
@@ -144,4 +144,8 @@ extension AppDelegate: NSMenuDelegate {
             menu.items.first?.view?.window?.appearance = NSAppearance(named: .darkAqua)
         }
     }
+
+    func menuDidClose(_ menu: NSMenu) {
+        NotificationCenter.default.post(name: .popoverDidClose, object: nil)
+    }
 }

--- a/ClaudeTokenCat/Sources/PopoverView.swift
+++ b/ClaudeTokenCat/Sources/PopoverView.swift
@@ -4,8 +4,26 @@ import SwiftUI
 
 struct PopoverView: View {
     @ObservedObject var usageManager: TokenUsageManager
+    @State private var showSettings: Bool = false
 
     var body: some View {
+        Group {
+            if showSettings {
+                settingsView
+            } else {
+                mainView
+            }
+        }
+        .frame(width: 280)
+        .preferredColorScheme(.dark)
+        .onReceive(NotificationCenter.default.publisher(for: .popoverDidClose)) { _ in
+            showSettings = false
+        }
+    }
+
+    // MARK: - Main View
+
+    private var mainView: some View {
         VStack(alignment: .leading, spacing: 12) {
             // Header
             VStack(alignment: .leading, spacing: 2) {
@@ -229,8 +247,20 @@ struct PopoverView: View {
 
             Divider()
 
-            // Quit + Animation toggle
+            // Settings + Quit
             HStack {
+                Button(action: { showSettings = true }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "gearshape")
+                        Text("Settings")
+                    }
+                    .font(.caption)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+
+                Spacer()
+
                 Button(action: {
                     NSApplication.shared.terminate(nil)
                 }) {
@@ -242,17 +272,49 @@ struct PopoverView: View {
                 }
                 .buttonStyle(.plain)
                 .foregroundColor(.secondary)
-
-                Spacer()
-
-                Toggle("Animate", isOn: $usageManager.animationEnabled)
-                .font(.caption)
-                .toggleStyle(MiniSwitchStyle())
             }
         }
         .padding(16)
-        .frame(width: 280)
-        .preferredColorScheme(.dark)
+    }
+
+    // MARK: - Settings View
+
+    private var settingsView: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            // Header with back button
+            HStack(spacing: 6) {
+                Button(action: { showSettings = false }) {
+                    Image(systemName: "chevron.left")
+                        .font(.caption)
+                        .fontWeight(.medium)
+                }
+                .buttonStyle(.plain)
+                .foregroundColor(.secondary)
+
+                Text("Settings")
+                    .font(.headline)
+
+                Spacer()
+            }
+
+            Divider()
+
+            // Animation toggle
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Animation")
+                        .font(.subheadline)
+                    Text("Animate the cat in the menu bar")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Toggle("", isOn: $usageManager.animationEnabled)
+                    .toggleStyle(MiniSwitchStyle())
+                    .labelsHidden()
+            }
+        }
+        .padding(16)
     }
 
     // MARK: - Helpers
@@ -300,4 +362,10 @@ private struct MiniSwitchStyle: ToggleStyle {
         }
         .buttonStyle(.plain)
     }
+}
+
+// MARK: - Notification Names
+
+extension Notification.Name {
+    static let popoverDidClose = Notification.Name("popoverDidClose")
 }

--- a/ClaudeTokenCat/Sources/PopoverView.swift
+++ b/ClaudeTokenCat/Sources/PopoverView.swift
@@ -95,7 +95,7 @@ struct PopoverView: View {
 
                 // Detail line
                 if !usageManager.isUsingMockData {
-                    Text(usageManager.timeRemaining != nil ? "Resets in \(usageManager.timeRemainingFormatted)" : "No active session")
+                    Text(usageManager.sessionResetDisplayText ?? "No active session")
                         .font(.caption)
                         .foregroundColor(.secondary)
                 }
@@ -128,8 +128,8 @@ struct PopoverView: View {
                     }
                     .frame(height: 4)
 
-                    if let formatted = usageManager.weeklyResetFormatted {
-                        Text("Resets \(formatted)")
+                    if let text = usageManager.weeklyResetDisplayText {
+                        Text(text)
                             .font(.caption)
                             .foregroundColor(.secondary)
                     }
@@ -313,11 +313,58 @@ struct PopoverView: View {
                     .toggleStyle(MiniSwitchStyle())
                     .labelsHidden()
             }
+
+            Divider()
+
+            // Menu bar percentage toggle
+            HStack {
+                VStack(alignment: .leading, spacing: 2) {
+                    Text("Menu Bar Percentage")
+                        .font(.subheadline)
+                    Text("Show usage % next to the cat")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                Spacer()
+                Toggle("", isOn: $usageManager.showPercentageInMenuBar)
+                    .toggleStyle(MiniSwitchStyle())
+                    .labelsHidden()
+            }
+
+            Divider()
+
+            // Reset time format
+            VStack(alignment: .leading, spacing: 6) {
+                Text("Reset Time Format")
+                    .font(.subheadline)
+                Picker("", selection: $usageManager.resetTimeFormat) {
+                    Text("Relative").tag(ResetTimeFormat.relative)
+                    Text("Absolute").tag(ResetTimeFormat.absolute)
+                    Text("Both").tag(ResetTimeFormat.both)
+                }
+                .pickerStyle(.segmented)
+                .labelsHidden()
+                .font(.caption2)
+                .controlSize(.small)
+
+                Text(resetTimeExample)
+                    .font(.caption2)
+                    .foregroundColor(.secondary)
+            }
         }
         .padding(16)
+        .frame(maxHeight: .infinity, alignment: .top)
     }
 
     // MARK: - Helpers
+
+    private var resetTimeExample: String {
+        switch usageManager.resetTimeFormat {
+        case .relative: return "e.g. Resets in 2d 7h"
+        case .absolute: return "e.g. Resets Fri 6:59 PM"
+        case .both:     return "e.g. Resets in 2d 7h (Fri 6:59 PM)"
+        }
+    }
 
     private var stateColor: Color {
         switch usageManager.catState {

--- a/README.md
+++ b/README.md
@@ -22,7 +22,11 @@ The cat animates in the menu bar based on your session usage:
 - **Real-time session tracking** - polls Claude's usage API every 5 minutes for live utilization data
 - **Manual refresh** - instant usage update with a single click
 - **Popover dashboard** - session %, weekly usage, extra usage credits, subscription tier, and reset countdown
-- **Zero-config auth** - reads Claude Code CLI credentials from macOS Keychain
+- **Settings panel** - configurable options that persist across launches:
+  - **Animation toggle** - pause/resume the cat animation
+  - **Menu bar percentage** - show usage % next to the cat icon
+  - **Reset time format** - choose relative ("2d 7h"), absolute ("Fri 6:59 PM"), or both
+- **Zero-config auth** - automatically reads Claude Code CLI credentials from macOS Keychain
 - **Demo mode** - falls back to mock data with a "Cycle State" button when not logged in or permission is denied
 
 ## Getting Started
@@ -132,3 +136,4 @@ OAuth credentials are read from Claude Code's stored authentication (macOS Keych
 - [Claude Code GitHub - Issue #13334](https://github.com/anthropics/claude-code/issues/13334) — confirms `user:profile` OAuth scope is required for usage data
 - [codelynx.dev - Claude Code Usage Limits in Statusline](https://codelynx.dev/posts/claude-code-usage-limits-statusline) — documents how the endpoint was discovered via network interception
 - [Anthropic API Rate Limits (official)](https://docs.anthropic.com/en/api/rate-limits) — official rate limit documentation (different from the usage endpoint above)
+- [Piskel](https://www.piskelapp.com/) — free online sprite editor used to create the pixel art animations


### PR DESCRIPTION
## Summary

Add a Settings panel to the popover with three user-configurable options: animation toggle, menu bar percentage display, and reset time format. Closes #5.

## Changes

- Replace inline "Animate" toggle with a Settings gear button that opens a settings sub-view
- Add "Menu Bar Percentage" toggle that composites usage % text into the status bar image, keeping the cat icon anchored in place
- Add "Reset Time Format" segmented picker (Relative / Absolute / Both) with a live example below the picker
- Relative format now handles days (e.g. "Resets in 2d 7h")
- Combined format uses parentheses: "Resets in 2d 7h (Fri 6:59 PM)"
- All settings persist across launches via UserDefaults
- Settings view resets to main view when popover closes

## Verification

- Tested all three settings toggles: animation on/off, percentage display on/off, and all three reset time format options
- Confirmed cat icon does not shift when toggling percentage display
- Verified reset time format applies to both session and weekly reset times
- Verified settings persist after quit and relaunch
- Confirmed popover always reopens to main view (not settings)